### PR TITLE
Regular update of lifecycle nodes list

### DIFF
--- a/include/ros2-lifecycle-monitoring/rviz_lifecycle_plugin.h
+++ b/include/ros2-lifecycle-monitoring/rviz_lifecycle_plugin.h
@@ -53,6 +53,7 @@ namespace rviz_lifecycle_plugin
         void add_client(const std::string& fully_qualified_name);
         void monitoring();
         void update_ui();
+        void update_ui_timer();
 
         void get_node_name_and_namespace(
             const std::string& fully_qualified_name,
@@ -68,6 +69,8 @@ namespace rviz_lifecycle_plugin
         QVBoxLayout *main_layout_;
         QTableWidget *nodes_states_table_;
         QScrollArea *scroll_area_;
+        QThread* thread_;
+        QTimer *timer_;
         
         // store fully qualified node names
         std::vector<std::string> lifecycle_nodes_names_;

--- a/include/ros2-lifecycle-monitoring/rviz_lifecycle_plugin.h
+++ b/include/ros2-lifecycle-monitoring/rviz_lifecycle_plugin.h
@@ -27,15 +27,14 @@ namespace rviz_lifecycle_plugin
     private:
         
         /*
-        *  Returns the fully qualified name of the lifecycle nodes
+        *  Update list clients to fetch the state of the lifecycle nodes
         */
-        void get_lifecycle_node_names(std::vector<std::string>& lifecycle_node_names);
+        void update_lifecycle_clients();
         
         /*
         *  Requests the status of the lifecycle node
         */
         void request_lifecycle_node_state(const std::string& node_name);
-
 
         /*
         *  Updates the table widget at given row. If row does not exist, a new row is created
@@ -47,13 +46,8 @@ namespace rviz_lifecycle_plugin
         */
         void set_label_color(QLabel* label, const LifecycleState& state);
 
-        /*
-        * Creates a client for the serivce /node_name/get_state and stores it in the clients_ map
-        */
-        void add_client(const std::string& fully_qualified_name);
         void monitoring();
         void update_ui();
-        void update_ui_timer();
 
         void get_node_name_and_namespace(
             const std::string& fully_qualified_name,
@@ -73,8 +67,7 @@ namespace rviz_lifecycle_plugin
         QTimer *timer_;
         
         // store fully qualified node names
-        std::vector<std::string> lifecycle_nodes_names_;
-        std::unordered_map<std::string, std::shared_ptr<GetStateClient>> clients_;
+        std::unordered_map<std::string, std::shared_ptr<GetStateClient>> lifecycle_clients_;
 
         // store the state of the lifecycle nodes to be able to provide it immediately by request, future development of CLI tool
         std::unordered_map<std::string, LifecycleState> lifecycle_node_states_;

--- a/src/rviz_lifecycle_plugin.cpp
+++ b/src/rviz_lifecycle_plugin.cpp
@@ -13,14 +13,9 @@ namespace rviz_lifecycle_plugin
         nodes_states_table_ = new QTableWidget(0, 2, this);
         scroll_area_ = new QScrollArea(this);
 
-        // thread_ = new QThread();
-
-        // connect(thread_, &QThread::started, this, &RvizLifecyclePlugin::update_ui);
-        // connect(thread_, &QThread::finished, this, &RvizLifecyclePlugin::deleteLater);
-
         timer_ = new QTimer(this);
-        connect(timer_, &QTimer::timeout, this, QOverload<>::of(&RvizLifecyclePlugin::update_ui_timer));
-        timer_->start(1000);
+        connect(timer_, &QTimer::timeout, this, QOverload<>::of(&RvizLifecyclePlugin::update_ui));
+        timer_->start(update_ui_interval_.count());
 
         scroll_area_->setWidget(nodes_states_table_);
         scroll_area_->setWidgetResizable(true);
@@ -31,13 +26,15 @@ namespace rviz_lifecycle_plugin
     }
 
     RvizLifecyclePlugin::~RvizLifecyclePlugin() {
-        // thread_->quit();
-        // thread_->wait();
-
         monitoring_thread_->join();
         spinner_thred_->join();
 
-        // delete thread_;
+        timer_->stop();
+
+        delete timer_;
+        delete scroll_area_;
+        delete nodes_states_table_;
+        delete main_layout_;
     }
 
     void RvizLifecyclePlugin::get_node_name_and_namespace(
@@ -54,10 +51,15 @@ namespace rviz_lifecycle_plugin
         }
     }
 
-    void RvizLifecyclePlugin::get_lifecycle_node_names(std::vector<std::string>& lifecycle_node_names){
+    void RvizLifecyclePlugin::update_lifecycle_clients(){
+        // We clear the clients and create them again
+        // to keep track of disappeared (aka died) nodes
+        for(const auto& kv : lifecycle_clients_){
+            lifecycle_clients_[kv.first] = nullptr;
+        }
+
         auto node_names = utility_node_->get_node_names();
         for(auto& fully_qualified_name : node_names){
-
             std::string node_name;
             std::string node_namespace;
             get_node_name_and_namespace(fully_qualified_name, node_name, node_namespace);
@@ -68,7 +70,13 @@ namespace rviz_lifecycle_plugin
             for(const auto& kv : services_names_types){
                 for(const auto& type_name : kv.second){
                     if(type_name.find("lifecycle") != std::string::npos){
-                        lifecycle_node_names.push_back(fully_qualified_name);
+                        std::string node_name;
+                        std::string node_namespace;
+                        get_node_name_and_namespace(fully_qualified_name, node_name, node_namespace);
+
+                        std::string service_name = fully_qualified_name + "/get_state";
+                        lifecycle_clients_[fully_qualified_name] = utility_node_->create_client<lifecycle_msgs::srv::GetState>(service_name);
+
                         lifecycle_found = true;
                         break;
                     }
@@ -79,7 +87,15 @@ namespace rviz_lifecycle_plugin
     }
 
     void RvizLifecyclePlugin::request_lifecycle_node_state(const std::string& fully_qualified_name){
-        auto client = clients_[fully_qualified_name];
+        auto client = lifecycle_clients_[fully_qualified_name];
+        
+        // If client is not available, we set the state to unknown
+        if(!client){
+            std::lock_guard<std::mutex> lock(lifecycle_node_states_mutex_);
+            lifecycle_node_states_[fully_qualified_name] = lifecycle_msgs::msg::State();
+            return;
+        }
+
         auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
         
         client->async_send_request(request, [this, fully_qualified_name](GetStateClient::SharedFuture response){
@@ -120,17 +136,6 @@ namespace rviz_lifecycle_plugin
         }
     }
 
-    void RvizLifecyclePlugin::add_client(const std::string& fully_qualified_node_name){
-        if(clients_.find(fully_qualified_node_name) == clients_.end()){
-            std::string node_name;
-            std::string node_namespace;
-            get_node_name_and_namespace(fully_qualified_node_name, node_name, node_namespace);
-
-            std::string service_name = fully_qualified_node_name + "/get_state";
-            clients_[fully_qualified_node_name] = utility_node_->create_client<lifecycle_msgs::srv::GetState>(service_name);
-        }
-    }
-
     void RvizLifecyclePlugin::onInitialize() {
         rviz_common::Panel::onInitialize();
 
@@ -141,66 +146,22 @@ namespace rviz_lifecycle_plugin
         });
 
         monitoring_thread_ = std::make_shared<std::thread>(&RvizLifecyclePlugin::monitoring, this);
-
-        // thread_->start();
-        // thread_->setPriority(QThread::LowPriority);
     }
 
     void RvizLifecyclePlugin::monitoring() {
         while(true){
-            RCLCPP_INFO(utility_node_->get_logger(), "Monitoring lifecycle nodes");
+            update_lifecycle_clients();
 
-            {
-                std::lock_guard<std::mutex> lock(lifecycle_node_states_mutex_);
-                lifecycle_nodes_names_ = {};
-                get_lifecycle_node_names(lifecycle_nodes_names_);
-
-                for(const auto& node_name : lifecycle_nodes_names_) {
-                    add_client(node_name);
-                }
+            for(const auto& kv : lifecycle_clients_){
+                request_lifecycle_node_state(kv.first);
             }
 
-            for(const auto& node_name : lifecycle_nodes_names_) {
-                request_lifecycle_node_state(node_name);
-            }
-
-            RCLCPP_INFO(utility_node_->get_logger(), "Monitoring lifecycle nodes DONE");
             std::this_thread::sleep_for(monitoring_interval_);
         }
     }
 
     void RvizLifecyclePlugin::update_ui() {
-        while(true){
-            // {   
-            //     std::lock_guard<std::mutex> lock(lifecycle_node_states_mutex_);
-
-            //     RCLCPP_INFO(utility_node_->get_logger(), "Updating UI");
-                          
-            //     size_t idx = 0;
-            //     for(const auto& kv : lifecycle_node_states_){
-            //         auto fully_qualified_node_name = kv.first;
-            //         auto state = kv.second;
-
-            //         std::string node_name;
-            //         std::string node_namespace;
-            //         get_node_name_and_namespace(fully_qualified_node_name, node_name, node_namespace);
-
-            //         update_table_widget(idx, node_name, state);
-
-            //         idx++;
-            //     }
-                
-            // }
-
-            std::this_thread::sleep_for(update_ui_interval_);
-        }
-    }
-
-    void RvizLifecyclePlugin::update_ui_timer() {
-        RCLCPP_INFO(utility_node_->get_logger(), "Updating UI - 1");
         std::lock_guard<std::mutex> lock(lifecycle_node_states_mutex_);
-
-        RCLCPP_INFO(utility_node_->get_logger(), "Updating UI");
                     
         size_t idx = 0;
         for(const auto& kv : lifecycle_node_states_){


### PR DESCRIPTION
Here I cover:
- #8 
- #9 

Now, the plugin will do lifecycle node discovery regularly. Also if some of the node dies, the plugin will show its state as unknown on the UI.